### PR TITLE
Are you sure it is base 64 and not base 45?

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The QR-code can be verified by:
 See details below.
 
 ### How
-The proxy sends a request with your cookies to medicare, and converts the JSON containing your vaccination data into a sign1 cose/cbor message, then compresses and base64s the result (as per the EU specs).
+The proxy sends a request with your cookies to medicare, and converts the JSON containing your vaccination data into a sign1 cose/cbor message, then compresses and base45s the result (as per the EU specs).
 
 ### Obtain a QR Code:
 


### PR DESCRIPTION
My previous quick technical check on the certificate technical background was that they were using the clever base45 encoding because that character set match one of the QR code encoding.

And here you are talking about base64... is it a typo, 
a bug, or if it is really base64, then where did I mix things?

See: https://github.com/ehn-dcc-development/hcert-spec/blob/main/README.md